### PR TITLE
Added parameter for rla log format

### DIFF
--- a/rails_database_time
+++ b/rails_database_time
@@ -20,6 +20,7 @@ This configuration section shows the defaults of the plugin:
 Options
   env.lines 50000                             # Number of lines to tail
   env.interval 300                            # Munin interval in seconds (used for graphs and caching)
+  env.log_format                              # request-log-analyzer log format (passed to '--format')
   env.request_log_analyzer '/usr/local/bin'   # Path to gem. Use this for Debian.
   env.graph_category 'App'                    # Graph Category. Defaults to App.
 
@@ -111,7 +112,7 @@ def fetch_or_create_yaml_file(log_file, debug = false)
   # Create temp file rla if needed
   unless File.exists?(temp_file)
     puts "Processing the last #{NUMBER_OF_LINES} lines of #{log_file} which are less then #{INTERVAL} seconds old." if debug    
-    status = `tail -n #{NUMBER_OF_LINES} #{log_file} | #{REQUEST_LOG_ANALYZER} - --after #{AFTER_TIME} -b --dump #{temp_file} 2>/dev/null`
+    status = `tail -n #{NUMBER_OF_LINES} #{log_file} | #{REQUEST_LOG_ANALYZER} - --after #{AFTER_TIME} #{LOG_FORMAT} -b --dump #{temp_file} 2>/dev/null`
 
     unless $?.success?
       $stderr.puts "failed executing request-log-analyzer. Is the gem path correct?"

--- a/rails_request_duration
+++ b/rails_request_duration
@@ -20,6 +20,7 @@ This configuration section shows the defaults of the plugin:
 Options
   env.lines 50000                             # Number of lines to tail
   env.interval 300                            # Munin interval in seconds (used for graphs and caching)
+  env.log_format                              # request-log-analyzer log format (passed to '--format')
   env.request_log_analyzer '/usr/local/bin'   # Path to gem. Use this for Debian.
   env.graph_category 'App'                    # Graph Category. Defaults to App.
 
@@ -111,7 +112,7 @@ def fetch_or_create_yaml_file(log_file, debug = false)
   # Create temp file rla if needed
   unless File.exists?(temp_file)
     puts "Processing the last #{NUMBER_OF_LINES} lines of #{log_file} which are less then #{INTERVAL} seconds old." if debug    
-    status = `tail -n #{NUMBER_OF_LINES} #{log_file} | #{REQUEST_LOG_ANALYZER} - --after #{AFTER_TIME} -b --dump #{temp_file} 2>/dev/null`
+    status = `tail -n #{NUMBER_OF_LINES} #{log_file} | #{REQUEST_LOG_ANALYZER} - --after #{AFTER_TIME} #{LOG_FORMAT} -b --dump #{temp_file} 2>/dev/null`
 
     unless $?.success?
       $stderr.puts "failed executing request-log-analyzer. Is the gem path correct?"

--- a/rails_request_error
+++ b/rails_request_error
@@ -20,6 +20,7 @@ This configuration section shows the defaults of the plugin:
 Options
   env.lines 50000                             # Number of lines to tail
   env.interval 300                            # Munin interval in seconds (used for graphs and caching)
+  env.log_format                              # request-log-analyzer log format (passed to '--format')
   env.request_log_analyzer '/usr/local/bin'   # Path to gem. Use this for Debian.
   env.graph_category 'App'                    # Graph Category. Defaults to App.
 
@@ -110,7 +111,7 @@ def fetch_or_create_yaml_file(log_file, debug = false)
   # Create temp file rla if needed
   unless File.exists?(temp_file)
     puts "Processing the last #{NUMBER_OF_LINES} lines of #{log_file} which are less then #{INTERVAL} seconds old." if debug    
-    status = `tail -n #{NUMBER_OF_LINES} #{log_file} | #{REQUEST_LOG_ANALYZER} - --after #{AFTER_TIME} -b --dump #{temp_file} 2>/dev/null`
+    status = `tail -n #{NUMBER_OF_LINES} #{log_file} | #{REQUEST_LOG_ANALYZER} - --after #{AFTER_TIME} #{LOG_FORMAT} -b --dump #{temp_file} 2>/dev/null`
 
     unless $?.success?
       $stderr.puts "failed executing request-log-analyzer. Is the gem path correct?"

--- a/rails_requests
+++ b/rails_requests
@@ -21,7 +21,7 @@ This configuration section shows the defaults of the plugin:
 Options
   env.lines 50000                             # Number of lines to tail
   env.interval 300                            # Munin interval in seconds (used for graphs and caching)
-  env.log_format rails3                       # Manually pass log format for failed autodetect
+  env.log_format                              # request-log-analyzer log format (passed to '--format')
   env.request_log_analyzer '/usr/local/bin'   # Path to gem. Use this for Debian.
   env.graph_category 'App'                    # Graph Category. Defaults to App.
 
@@ -53,7 +53,7 @@ GRAPH_CATEGORY  = ENV['graph_category'] || 'App'
 INTERVAL        = ENV['interval'] ? ENV['interval'].to_i : 300
 NUMBER_OF_LINES = ENV['lines'] || 50000
 LOG_FILE        = ENV['log_file']
-LOG_FORMAT      = "--format #{ENV['log_format']}" if ENV['log_format']
+LOG_FORMAT      = "--format #{ENV['log_format']}"
 AFTER_TIME      = (Time.now - INTERVAL).strftime('%Y%m%d%H%M%S')
 FLOOR_TIME      = Time.at((Time.now.to_f / INTERVAL).floor * INTERVAL)
 
@@ -120,6 +120,7 @@ def fetch_or_create_yaml_file(log_file, debug = false)
     puts "Processing the last #{NUMBER_OF_LINES} lines of #{log_file} which are less then #{INTERVAL} seconds old." if debug    
     p "tail -n #{NUMBER_OF_LINES} #{log_file} | #{REQUEST_LOG_ANALYZER} - --after #{AFTER_TIME} #{LOG_FORMAT} -b --dump #{temp_file} 2>/dev/null"
     status = `tail -n #{NUMBER_OF_LINES} #{log_file} | #{REQUEST_LOG_ANALYZER} - --after #{AFTER_TIME} #{LOG_FORMAT} -b --dump #{temp_file} 2>/dev/null`
+
 
     unless $?.success?
       $stderr.puts "failed executing request-log-analyzer. Is the path to the binary correct?"

--- a/rails_requests
+++ b/rails_requests
@@ -21,7 +21,7 @@ This configuration section shows the defaults of the plugin:
 Options
   env.lines 50000                             # Number of lines to tail
   env.interval 300                            # Munin interval in seconds (used for graphs and caching)
-  env.log_format                              # Manually pass log format for failed autodetect
+  env.log_format rails3                       # Manually pass log format for failed autodetect
   env.request_log_analyzer '/usr/local/bin'   # Path to gem. Use this for Debian.
   env.graph_category 'App'                    # Graph Category. Defaults to App.
 

--- a/rails_requests
+++ b/rails_requests
@@ -21,6 +21,7 @@ This configuration section shows the defaults of the plugin:
 Options
   env.lines 50000                             # Number of lines to tail
   env.interval 300                            # Munin interval in seconds (used for graphs and caching)
+  env.log_format                              # Manually pass log format for failed autodetect
   env.request_log_analyzer '/usr/local/bin'   # Path to gem. Use this for Debian.
   env.graph_category 'App'                    # Graph Category. Defaults to App.
 
@@ -52,6 +53,7 @@ GRAPH_CATEGORY  = ENV['graph_category'] || 'App'
 INTERVAL        = ENV['interval'] ? ENV['interval'].to_i : 300
 NUMBER_OF_LINES = ENV['lines'] || 50000
 LOG_FILE        = ENV['log_file']
+LOG_FORMAT      = "--format #{ENV['log_format']}" if ENV['log_format']
 AFTER_TIME      = (Time.now - INTERVAL).strftime('%Y%m%d%H%M%S')
 FLOOR_TIME      = Time.at((Time.now.to_f / INTERVAL).floor * INTERVAL)
 
@@ -116,8 +118,8 @@ def fetch_or_create_yaml_file(log_file, debug = false)
   # Create temp file rla if needed
   unless File.exists?(temp_file)
     puts "Processing the last #{NUMBER_OF_LINES} lines of #{log_file} which are less then #{INTERVAL} seconds old." if debug    
-    p "tail -n #{NUMBER_OF_LINES} #{log_file} | #{REQUEST_LOG_ANALYZER} - --after #{AFTER_TIME} -b --dump #{temp_file} 2>/dev/null"
-    status = `tail -n #{NUMBER_OF_LINES} #{log_file} | #{REQUEST_LOG_ANALYZER} - --after #{AFTER_TIME} -b --dump #{temp_file} 2>/dev/null`
+    p "tail -n #{NUMBER_OF_LINES} #{log_file} | #{REQUEST_LOG_ANALYZER} - --after #{AFTER_TIME} #{LOG_FORMAT} -b --dump #{temp_file} 2>/dev/null"
+    status = `tail -n #{NUMBER_OF_LINES} #{log_file} | #{REQUEST_LOG_ANALYZER} - --after #{AFTER_TIME} #{LOG_FORMAT} -b --dump #{temp_file} 2>/dev/null`
 
     unless $?.success?
       $stderr.puts "failed executing request-log-analyzer. Is the path to the binary correct?"

--- a/rails_view_render_time
+++ b/rails_view_render_time
@@ -20,6 +20,7 @@ This configuration section shows the defaults of the plugin:
 Options
   env.lines 50000                             # Number of lines to tail
   env.interval 300                            # Munin interval in seconds (used for graphs and caching)
+  env.log_format                              # request-log-analyzer log format (passed to '--format')
   env.request_log_analyzer '/usr/local/bin'   # Path to gem. Use this for Debian.
   env.graph_category 'App'                    # Graph Category. Defaults to App.
 
@@ -111,7 +112,7 @@ def fetch_or_create_yaml_file(log_file, debug = false)
   # Create temp file rla if needed
   unless File.exists?(temp_file)
     puts "Processing the last #{NUMBER_OF_LINES} lines of #{log_file} which are less then #{INTERVAL} seconds old." if debug    
-    status = `tail -n #{NUMBER_OF_LINES} #{log_file} | #{REQUEST_LOG_ANALYZER} - --after #{AFTER_TIME} -b --dump #{temp_file} 2>/dev/null`
+    status = `tail -n #{NUMBER_OF_LINES} #{log_file} | #{REQUEST_LOG_ANALYZER} - --after #{AFTER_TIME} #{LOG_FORMAT} -b --dump #{temp_file} 2>/dev/null`
 
     unless $?.success?
       $stderr.puts "failed executing request-log-analyzer. Is the gem path correct?"


### PR DESCRIPTION
When passing log data through a pipe, rla's format auto-detection fails. This causes the rails_\* munin plugins to fail, as it expects rla to properly auto-detect the log format. As a workaround, I've added a configuration parameter to explicitly specify the log file format.
### Statement of problem

```
tail -n 1000 production.log | request-log-analyzer -
```

When _production.log_ is a Rails 3 log, rla reports teaser_check_failed for all requests.

```
tail -n 1000 production.log | request-log-analyzer - --format rails3
```

When _production.log_ is a Rails 3 log, and format is passed, rla properly processes requests.

Willem indicates that auto-detection when reading from stdin is problematic because we can't simply back-up and start over after detection occurs.
### Location in project

Anywhere request-log-analyzer is provided input from `tail`.
