### PR TITLE
Passenger_* plugins not working when several passenger are running on the server

### DIFF
--- a/passenger_queue
+++ b/passenger_queue
@@ -18,6 +18,7 @@ This configuration section shows the defaults of the plugin:
   
 Options
   env.passenger_status '/path/to/passenger-status'  # Path to passenger-status
+  env.apache_pid_file '/path/to/apache2.pid'        # Path to passenger-status (like /var/run/apache2.pid)
   env.graph_category 'App'                          # Graph Category. Defaults to App.
 
 ln -s /usr/share/munin/plugins/passenger_queue /etc/munin/plugins/passenger_queue
@@ -48,6 +49,10 @@ POD
 # Globals
 GRAPH_CATEGORY   = ENV['graph_category'] || 'App'
 PASSENGER_STATUS = ENV['passenger_status'] || '/usr/local/bin/passenger-status'
+#to use if you have multiple passenger on the host like phusion passenger standalon
+if ENV['passenger_pid_file']
+  PASSENGER_STATUS = "cat #{ENV['apache_pid_file']} | xargs -0 #{PASSENGER_STATUS}"
+end
 
 # Check if this plugin can run
 def autoconf

--- a/passenger_queue
+++ b/passenger_queue
@@ -49,8 +49,8 @@ POD
 # Globals
 GRAPH_CATEGORY   = ENV['graph_category'] || 'App'
 PASSENGER_STATUS = ENV['passenger_status'] || '/usr/local/bin/passenger-status'
-#to use if you have multiple passenger on the host like phusion passenger standalon
-if ENV['passenger_pid_file']
+#to use if you have multiple passenger on the host like phusion passenger standalone
+if ENV['apache_pid_file']
   PASSENGER_STATUS = "cat #{ENV['apache_pid_file']} | xargs -0 #{PASSENGER_STATUS}"
 end
 

--- a/passenger_status
+++ b/passenger_status
@@ -49,7 +49,7 @@ POD
 GRAPH_CATEGORY   = ENV['graph_category'] || 'App'
 PASSENGER_STATUS = ENV['passenger_status'] || '/usr/local/bin/passenger-status'
 #to use if you have multiple passenger on the host like phusion passenger standalone
-if ENV['passenger_pid_file']
+if ENV['apache_pid_file']
   PASSENGER_STATUS = "cat #{ENV['apache_pid_file']} | xargs -0 #{PASSENGER_STATUS}"
 end
 

--- a/passenger_status
+++ b/passenger_status
@@ -18,6 +18,7 @@ This configuration section shows the defaults of the plugin:
   
 Options
   env.passenger_status '/path/to/passenger-status'  # Path to passenger-status
+  env.apache_pid_file '/path/to/apache2.pid'        # Path to passenger-status (like /var/run/apache2.pid)
   env.graph_category 'App'                          # Graph Category. Defaults to App.
 
 ln -s /usr/share/munin/plugins/passenger_status /etc/munin/plugins/passenger_status
@@ -47,6 +48,10 @@ POD
 # Globals
 GRAPH_CATEGORY   = ENV['graph_category'] || 'App'
 PASSENGER_STATUS = ENV['passenger_status'] || '/usr/local/bin/passenger-status'
+#to use if you have multiple passenger on the host like phusion passenger standalone
+if ENV['passenger_pid_file']
+  PASSENGER_STATUS = "cat #{ENV['apache_pid_file']} | xargs -0 #{PASSENGER_STATUS}"
+end
 
 # Check if this plugin can run
 def autoconf


### PR DESCRIPTION
In our production environment we have 2 passenger (apache and standalone) running. Consequently the passenger-status command needs the pid as an argument. I have made a fork to configure the path of the pid file in the munin-node file. Please fill free to pull the change.
