### PR TITLE
Added ruby-1.9 magic comment

### DIFF
--- a/munin/munin_passenger_queue
+++ b/munin/munin_passenger_queue
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# encoding: utf-8
+
 pod=<<-POD
 
 =head1 NAME


### PR DESCRIPTION
The following errors has occurred because munin_passenger_queue contains UTF-8 string.

$ ruby-1.9.2-p320 munin_passenger_queue  
munin_passenger_queue:40: invalid multibyte char (US-ASCII)
munin_passenger_queue:2: syntax error, unexpected $end, expecting tSTRING_CONTENT or tSTRING_DBEG or tSTRING_DVAR or tSTRING_E
ND
