### PR TITLE
Match version 4 or 5 in passenger-status output.

### DIFF
--- a/lib/munin/plugins/passenger_queue.rb
+++ b/lib/munin/plugins/passenger_queue.rb
@@ -22,7 +22,7 @@ CONFIG
 
     def run
       status = run_command(passenger_status, debug)
-      if status =~ /Version : 4/
+      if status =~ /Version : [45]/
         status =~ /Requests in top-level queue\s+:\s+(\d+)/
         puts "requests.value #{$1}"
       else

--- a/lib/munin/plugins/passenger_status.rb
+++ b/lib/munin/plugins/passenger_status.rb
@@ -31,7 +31,7 @@ CONFIG
     def run
       status = run_command(passenger_status, debug)
 
-      if status =~ /Version : 4/
+      if status =~ /Version : [45]/
         run_version4(status)
       else
         run_version3(status)


### PR DESCRIPTION
This minor change allows the use of munin-plugins-rails with Passenger version 5. The output of passenger-status in v5 is otherwise compatible with the v4 regex matching.

Before change:

```
    $ munin-run munin_passenger_queue
    requests.value 
    $ munin-run munin_passenger_status 
    max.value 
    running.value 
    active.value 
    sessions.value 0
```

After change:

```
    $ munin-run munin_passenger_queue
    requests.value 0
    $ munin-run munin_passenger_status 
    max.value 6
    running.value 6
    active.value 0
    sessions.value 0
```

I used a character class for matching, but I'm wondering if this shouldn't be refactored to a capture group and a case block for better modularity. I may submit a separate pull request with an altered implementation.
