### PR TITLE
Update "help" output to fix railsplugins install command

### DIFF
--- a/bin/request-log-analyzer-munin
+++ b/bin/request-log-analyzer-munin
@@ -20,11 +20,11 @@ else
   puts "  request-log-analyzer-munin install"
   puts
   puts "To install railsplugins:"
-  puts "  request-log-analyzer-munin <app-name> <log-file>"
+  puts "  request-log-analyzer-munin add <app-name> <log-file>"
   puts
   puts "Examples:"
   puts "  request-log-analyzer-munin install"
-  puts "  request-log-analyzer-munin MyAwesomeApp /srv/my_app/current/log/production.log"
+  puts "  request-log-analyzer-munin add MyAwesomeApp /srv/my_app/current/log/production.log"
   puts
   exit(0)
 end


### PR DESCRIPTION
This documentation didn't fit with the main documentation from https://github.com/barttenbrinke/munin-plugins-rails/ and the implementation, which suggests you should run "request-log-analyzer-munin add <app-name> <log-file>". This doc was missing the "add" keyword.
